### PR TITLE
Upgrade dependencies, fix tests, use through2

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var through = require('through');
+var through2 = require('through2');
 
 /**
  * @alias stream-sample
@@ -35,7 +35,7 @@ var through = require('through');
 function streamSample(sampleCount) {
     var sample = new Array(sampleCount),
         i = 0;
-    return through(function write(data) {
+    return through2.obj(function (data, enc, callback) {
         // Fill the initial sample.
         if (i < sampleCount) {
             sample[i] = data;
@@ -49,6 +49,7 @@ function streamSample(sampleCount) {
         }
         i++;
         this.push(sample);
+        callback();
     });
 }
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "sample streams using reservoir sampling",
   "main": "index.js",
   "scripts": {
-    "test": "prova test.js",
+    "test": "tape test.js",
     "doc": "dox -r < index.js | doxme --readme > README.md"
   },
   "keywords": [
@@ -15,11 +15,13 @@
   ],
   "author": "Tom MacWright",
   "license": "ISC",
+  "dependencies": {
+    "through2": "^2.0.1"
+  },
   "devDependencies": {
-    "dox": "^0.6.1",
+    "dox": "^0.9.0",
     "doxme": "^1.8.2",
-    "prova": "^2.1.1",
-    "through": "^2.3.6"
+    "tape": "^4.6.0"
   },
   "repository": {
     "type": "git",

--- a/test.js
+++ b/test.js
@@ -1,4 +1,4 @@
-var test = require('prova'),
+var test = require('tape'),
     streamSample = require('./');
 
 test('stream-sample [1,2,3]', function(t) {
@@ -8,9 +8,9 @@ test('stream-sample [1,2,3]', function(t) {
     sampler.on('data', function(sample) {
         t.equal(sample.length, 3);
         t.deepEqual(sample, [1, 2, 3]);
-        t.end();
     });
     sampler.write(3);
+    t.end();
 });
 
 test('stream-sample lots', function(t) {
@@ -24,8 +24,8 @@ test('stream-sample lots', function(t) {
             t.ok(s > 0);
             t.ok(s < 50);
         });
-        t.end();
     });
     sampler.write(Math.random() * 50);
     sampler.end();
+    t.end();
 });


### PR DESCRIPTION
Hi there and thanks for publishing this module.
I hope you find these suggestions useful.

prova is not installable anymore. it depends on ansi-codes that
has been removed from npm.
Replaced it with tape.

Using through2 instead of through to support pull streams
rather than push streams.

The tests were ending on each sampled piece of data.
It was not a problem with through but executing with through2
things became more asynchronous and was failing the test.
Also the second test was sampling only once. Now we do sample
as many as the tests intended.

Thanks for your attention!
