### PR TITLE
Support for stream-concat behavior

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,9 +32,20 @@ var through2 = require('through2');
  *
  * for (var i = 0; i < 100; i++) sampler.push(Math.random());
  */
-function streamSample(sampleCount) {
-    var sample = new Array(sampleCount),
-        i = 0;
+function streamSample(sampleCountOrArray, lastOneOnly) {
+    var sample = [],
+        sampleCount = 0;
+    if (Array.isArray(sampleCountOrArray)) {
+      sample = sampleCountOrArray;
+      sampleCount = sample.length;
+      if (lastOneOnly === undefined) {
+        lastOneOnly = true;
+      }
+    } else {
+      sampleCount = sampleCountOrArray;
+      sample = new Array(sampleCount);
+    }
+    var i = 0;
     return through2.obj(function (data, enc, callback) {
         // Fill the initial sample.
         if (i < sampleCount) {
@@ -48,8 +59,15 @@ function streamSample(sampleCount) {
             }
         }
         i++;
-        this.push(sample);
+        if (!lastOneOnly) {
+          this.push(sample);
+        }
         callback();
+    }, function flush(cb) {
+      if (lastOneOnly) {
+        this.push(sample);
+      }
+      cb();
     });
 }
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var through = require('through');
+var through2 = require('through2');
 
 /**
  * @alias stream-sample
@@ -35,7 +35,7 @@ var through = require('through');
 function streamSample(sampleCount) {
     var sample = new Array(sampleCount),
         i = 0;
-    return through(function write(data) {
+    return through2.obj(function (data, enc, callback) {
         // Fill the initial sample.
         if (i < sampleCount) {
             sample[i] = data;
@@ -49,6 +49,7 @@ function streamSample(sampleCount) {
         }
         i++;
         this.push(sample);
+        callback();
     });
 }
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "sample streams using reservoir sampling",
   "main": "index.js",
   "scripts": {
-    "test": "prova test.js",
+    "test": "tape test.js",
     "doc": "dox -r < index.js | doxme --readme > README.md"
   },
   "keywords": [
@@ -15,11 +15,13 @@
   ],
   "author": "Tom MacWright",
   "license": "ISC",
+  "dependencies": {
+    "through2": "^2.0.1"
+  },
   "devDependencies": {
-    "dox": "^0.6.1",
+    "dox": "^0.9.0",
     "doxme": "^1.8.2",
-    "prova": "^2.1.1",
-    "through": "^2.3.6"
+    "tape": "^4.6.0"
   },
   "repository": {
     "type": "git",

--- a/test.js
+++ b/test.js
@@ -1,4 +1,4 @@
-var test = require('prova'),
+var test = require('tape'),
     streamSample = require('./');
 
 test('stream-sample [1,2,3]', function(t) {
@@ -8,9 +8,9 @@ test('stream-sample [1,2,3]', function(t) {
     sampler.on('data', function(sample) {
         t.equal(sample.length, 3);
         t.deepEqual(sample, [1, 2, 3]);
-        t.end();
     });
     sampler.write(3);
+    t.end();
 });
 
 test('stream-sample lots', function(t) {
@@ -24,8 +24,8 @@ test('stream-sample lots', function(t) {
             t.ok(s > 0);
             t.ok(s < 50);
         });
-        t.end();
     });
     sampler.write(Math.random() * 50);
     sampler.end();
+    t.end();
 });

--- a/test.js
+++ b/test.js
@@ -1,4 +1,4 @@
-var test = require('tape'),
+var test = require('tape-async'),
     streamSample = require('./');
 
 test('stream-sample [1,2,3]', function(t) {
@@ -12,6 +12,59 @@ test('stream-sample [1,2,3]', function(t) {
     sampler.write(3);
     t.end();
 });
+
+test('stream-sample when sample size bigger than stream', function(t) {
+    var sampler = streamSample(5);
+    var nbOfSamplesIssued = 0;
+    sampler.write(1);
+    sampler.write(2);
+    sampler.on('data', function(sample) {
+        nbOfSamplesIssued++;
+        t.equal(sample.length, 5);
+        t.deepEqual(sample, [1, 2, 3, , ,]);
+    });
+    sampler.write(3);
+    sampler.end();
+    sampler.on('end', function () {
+      t.equal(nbOfSamplesIssued, 3);
+      t.end();
+    });
+});
+
+test('stream-sample when emitting only the last sample', function(t) {
+    var sampler = streamSample(5, true);
+    var nbOfSamplesIssued = 0;
+    sampler.write(1);
+    sampler.write(2);
+    sampler.on('data', function(sample) {
+        nbOfSamplesIssued++;
+        t.equal(sample.length, 5);
+        t.deepEqual(sample, [1, 2, 3, , ,]);
+    });
+    sampler.write(3);
+    sampler.end();
+    sampler.on('end', function () {
+      t.equal(nbOfSamplesIssued, 1);
+      t.end();
+    });
+});
+
+test('stream-sample when using a collector', function(t) {
+    var collector = new Array(5)
+    var sampler = streamSample(collector);
+    var nbOfSamplesIssued = 0;
+    sampler.write(1);
+    sampler.write(2);
+    sampler.on('data', function() {});
+    sampler.write(3);
+    sampler.end();
+    sampler.on('end', function () {
+      t.deepEqual(collector, [1, 2, 3, , ,]);
+      t.end();
+    });
+});
+
+
 
 test('stream-sample lots', function(t) {
     var sampler = streamSample(10);


### PR DESCRIPTION
This PR contains the dependency upgrades and the refactoring to use through2 instead of through.
If one passes an array to collect the sample, the sample will be only issued once at the end of the stream.
This makes it behave like a sampling stream-concat.

If it is interesting for some other project than my own let me know.
Cheers!
